### PR TITLE
Fix description spacing

### DIFF
--- a/oa-blog.html
+++ b/oa-blog.html
@@ -8,7 +8,7 @@
     
     <title>OA-Osteopathie Blog: Wissenswertes rund um Osteopathie Hamburg</title>
 
-    <meta name="description" content="Der&#x20;Osteopathie&#x20;Blog&#x20;vermittelt&#x20;Wissenswertes&#x20;rundum&#x20;Osteopathie,&#x20;die&#x20;verschiedenen&#x20;Anwendungsbereiche&#x20;und&#x20;Behandlungsans&#x00E4;tze&#x20;von&#x20;Osteopathie&#x20;Hamburg">
+    <meta name="description" content="Der&#x20;Osteopathie&#x20;Blog&#x20;vermittelt&#x20;Wissenswertes&#x20;rund&#x20;um&#x20;Osteopathie,&#x20;die&#x20;verschiedenen&#x20;Anwendungsbereiche&#x20;und&#x20;Behandlungsans&#x00E4;tze&#x20;von&#x20;Osteopathie&#x20;Hamburg">
     <meta name="keywords" content="Osteopathie&#x20;Alsen&#x20;Osteopathie&#x20;Hamburg&#x20;Osteopathie&#x20;Eimsb&#x00FC;ttel&#x20;Osteopathie&#x20;Hamburg&#x20;Mitte">
 
 
@@ -18,7 +18,7 @@
 
 <meta property="og:url" content="oa-blog.html" />
 <meta property="og:site_name" content="www.osteoalsen.de" />
-    <meta property="og:description" content="Der&#x20;Osteopathie&#x20;Blog&#x20;vermittelt&#x20;Wissenswertes&#x20;rundum&#x20;Osteopathie,&#x20;die&#x20;verschiedenen&#x20;Anwendungsbereiche&#x20;und&#x20;Behandlungsans&#x00E4;tze&#x20;von&#x20;Osteopathie&#x20;Hamburg" />
+    <meta property="og:description" content="Der&#x20;Osteopathie&#x20;Blog&#x20;vermittelt&#x20;Wissenswertes&#x20;rund&#x20;um&#x20;Osteopathie,&#x20;die&#x20;verschiedenen&#x20;Anwendungsbereiche&#x20;und&#x20;Behandlungsans&#x00E4;tze&#x20;von&#x20;Osteopathie&#x20;Hamburg" />
 
 
 <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- correct "rundum Osteopathie" to "rund um Osteopathie" in blog HTML

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_683b72d2f0d4832db543f4aa508c9ccc