### PR TITLE
Fix broken blog links on o-block page

### DIFF
--- a/scripts/load-posts.js
+++ b/scripts/load-posts.js
@@ -4,8 +4,7 @@ fetch('posts.json')
     const container = document.getElementById('posts');
     if (!container) return;
     container.innerHTML = posts.map(post => {
-      const file = post.file.replace(/^blog\//, '').replace(/\.md$/, '.html');
-      const url = `dist/blog/${file}`;
+      const url = `post.html?file=${encodeURIComponent(post.file)}`;
       return `
       <a class="post-preview" href="${url}">
         ${post.image ? `<img class="post-image" src="${post.image}" alt="">` : ''}


### PR DESCRIPTION
## Summary
- fix blog links on o-block by using `post.html?file=...`

## Testing
- `node tests/test_generate_posts.js`

------
https://chatgpt.com/codex/tasks/task_b_683bb04737f4832db476c4e7c0e27a50